### PR TITLE
feat: Compressed tarball package files

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -62,7 +62,17 @@ object itest extends MillIntegrationTestModule {
   override def testInvocations = Seq(
     PathRef(testBase / "example") -> Seq(
       TestInvocation.Targets(Seq("universalStage")),
-      TestInvocation.Targets(Seq("universalPackage"))
+      TestInvocation.Targets(Seq("universalPackage")),
+      TestInvocation.Targets(Seq("universalPackageZip")),
+      TestInvocation.Targets(Seq("universalPackageTarZstd")),
+      TestInvocation.Targets(Seq("universalPackageTarGzip")),
+      TestInvocation.Targets(Seq("universalPackageTarBzip2")),
+      TestInvocation.Targets(Seq("universalPackageTarXz")),
+      TestInvocation.Targets(Seq("universalStagePackageZip")),
+      TestInvocation.Targets(Seq("universalStagePackageTarZstd")),
+      TestInvocation.Targets(Seq("universalStagePackageTarGzip")),
+      TestInvocation.Targets(Seq("universalStagePackageTarBzip2")),
+      TestInvocation.Targets(Seq("universalStagePackageTarXz"))
     )
   )
 

--- a/build.sc
+++ b/build.sc
@@ -5,6 +5,7 @@ import mill._
 import mill.scalalib._
 import mill.scalalib.publish._
 import mill.scalalib.api.ZincWorkerUtil.scalaNativeBinaryVersion
+import scalafmt._
 
 import de.tobiasroeser.mill.integrationtest._
 import io.kipp.mill.ci.release.CiReleaseModule
@@ -20,7 +21,7 @@ object Versions {
   lazy val scala = "2.13.12"
 }
 
-object `mill-universal-packager` extends ScalaModule with CiReleaseModule {
+object `mill-universal-packager` extends ScalaModule with CiReleaseModule with ScalafmtModule {
 
   override def scalaVersion = Versions.scala
 

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/FileUtil.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/FileUtil.scala
@@ -6,16 +6,15 @@ import java.nio.file.attribute.{PosixFilePermission, PosixFilePermissions}
 
 import scala.util.Try
 
-/**
-  * Setting the file permissions
+/** Setting the file permissions
   */
 object chmod {
 
-  /**
-    * Using java 7 nio API to set the permissions.
+  /** Using java 7 nio API to set the permissions.
     *
     * @param file
-    * @param perms in octal format
+    * @param perms
+    *   in octal format
     */
   def apply(file: File, perms: String): Unit = {
     val posix = permissions(perms)
@@ -36,17 +35,17 @@ object chmod {
       sys.error("Error setting permissions " + perms + " on " + file.getAbsolutePath + ": " + e.getMessage)
     }
   }
+
 }
 
-/**
-  * Converts a octal unix permission representation into
-  * a java `PosiFilePermissions` compatible string.
+/** Converts a octal unix permission representation into a java `PosiFilePermissions` compatible string.
   */
 object permissions {
 
-  /**
-    * @param perms in octal format
-    * @return java 7 posix file permissions
+  /** @param perms
+    *   in octal format
+    * @return
+    *   java 7 posix file permissions
     */
   def apply(perms: String): java.util.Set[PosixFilePermission] =
     PosixFilePermissions fromString convert(perms)

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/archetypes/TemplateWriter.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/archetypes/TemplateWriter.scala
@@ -3,43 +3,43 @@ package io.github.hoangmaihuy.mill.packager.archetypes
 import scala.annotation.unused
 import scala.io.{Codec, Source}
 
-/**
-  * This object provides methods to generate scripts from templates. This involves
+/** This object provides methods to generate scripts from templates. This involves
   *
-  * <ol>
-  * <li>procesing - replacing a placeholders with actual values</li>
-  * <li>TODO: validating - check the script if there are no remaining placeholders</li>
-  * </ol>
+  * <ol> <li>procesing - replacing a placeholders with actual values</li> <li>TODO: validating - check the script if
+  * there are no remaining placeholders</li> </ol>
   *
-  * @example a bash script can be generated like this
-  * {{{
+  * @example
+  *   a bash script can be generated like this
+  *   {{{
   *  val template = getClass getResource "template-your-bashscript"
   *  val replacements = Seq("name" -> "your-app", "custom" -> "1")
   *  TemplateWriter.generateScript(template, replacements)
-  * }}}
+  *   }}}
   *
-  * @example a bat script can be generated like this
-  * {{{
+  * @example
+  *   a bat script can be generated like this
+  *   {{{
   *  val template = getClass getResource "template-your-batscript"
   *  val replacements = Seq("name" -> "your-app", "custom" -> "1")
   *  TemplateWriter.generateScript(template, replacements, "\r\n", TemplateWriter.batFriendlyKeySurround)
-  * }}}
+  *   }}}
   *
   * TODO move out of archetypes package
   */
 object TemplateWriter {
+
   def defaultCharset: java.nio.charset.Charset =
     java.nio.charset.Charset.forName("UTF-8")
 
   def bashFriendlyKeySurround(key: String) =
     "\\$\\{\\{" + key + "\\}\\}"
+
   def batFriendlyKeySurround(key: String) =
     "@@" + key + "@@"
 
   private def replace(line: String, replacements: Seq[(String, String)], keySurround: String => String): String =
-    replacements.foldLeft(line) {
-      case (line, (key, value)) =>
-        keySurround(key).r.replaceAllIn(line, java.util.regex.Matcher.quoteReplacement(value))
+    replacements.foldLeft(line) { case (line, (key, value)) =>
+      keySurround(key).r.replaceAllIn(line, java.util.regex.Matcher.quoteReplacement(value))
     }
 
   private def replaceValues(
@@ -83,11 +83,12 @@ object TemplateWriter {
   ): String =
     replaceValues(source.split(eol).toSeq, replacements, eol, keySurround)
 
-  /**
-    * @param lines
+  /** @param lines
     * @param replacements
-    * @param keySurround defaults to bashFriendlyKeySurround
-    * @param charset defaults to UTF-8
+    * @param keySurround
+    *   defaults to bashFriendlyKeySurround
+    * @param charset
+    *   defaults to UTF-8
     */
   def generateScriptFromLines(
     lines: Seq[String],
@@ -96,4 +97,5 @@ object TemplateWriter {
     @unused charset: java.nio.charset.Charset = defaultCharset
   ): Seq[String] =
     replaceValues(lines, replacements, keySurround)
+
 }

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/archetypes/scripts/BashStartScriptModule.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/archetypes/scripts/BashStartScriptModule.scala
@@ -6,7 +6,7 @@ import mill._
 import io.github.hoangmaihuy.mill.packager.archetypes.{JavaAppPackagingModule, TemplateWriter}
 import io.github.hoangmaihuy.mill.packager._
 
-/** == Bash StartScript Plugin ==
+/** ==Bash StartScript Plugin==
   *
   * This plugins creates a start bash script to run an application built with the
   * [[io.github.hoangmaihuy.mill.packager.archetypes.JavaAppPackagingModule]].
@@ -86,9 +86,10 @@ trait BashStartScriptModule extends Module with CommonStartScriptGenerator { sel
 
     /** Creates the block of defines for a script.
       *
-      * @param appClasspath A sequence of relative-locations (to the lib/ folder) of jars
-      *                     to include on the classpath.
-      * @param configFile An (optional) filename from which the script will read arguments.
+      * @param appClasspath
+      *   A sequence of relative-locations (to the lib/ folder) of jars to include on the classpath.
+      * @param configFile
+      *   An (optional) filename from which the script will read arguments.
       */
     def apply(appClasspath: Seq[String], configFile: Option[String], bundledJvm: Option[String]): Seq[String] =
       (configFile map configFileDefine).toSeq ++

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/archetypes/scripts/CommonStartScriptGenerator.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/archetypes/scripts/CommonStartScriptGenerator.scala
@@ -30,7 +30,8 @@ trait CommonStartScriptGenerator {
   protected[this] val keySurround: String => String
 
   /** Set executable bit of the generated scripts to this value
-    * @todo Does it work when building archives on hosts that do not support such permission?
+    * @todo
+    *   Does it work when building archives on hosts that do not support such permission?
     */
   protected[this] val executableBitValue: Boolean
 
@@ -49,9 +50,8 @@ trait CommonStartScriptGenerator {
     def withScriptName(scriptName: String): SpecializedScriptConfig
   }
 
-  /** The type of specialized ScriptConfig.
-    * This enables callback methods of the concrete plugin implementations
-    * to use fields of config that only exist in their ScriptConfig specialization.
+  /** The type of specialized ScriptConfig. This enables callback methods of the concrete plugin implementations to use
+    * fields of config that only exist in their ScriptConfig specialization.
     */
   protected[this] type SpecializedScriptConfig <: ScriptConfig
 
@@ -129,10 +129,14 @@ trait CommonStartScriptGenerator {
   private[this] def mainScriptName(config: ScriptConfig): String =
     config.executableScriptName + scriptSuffix
 
-  /** @param mainClass - Main class added to the java command
-    * @param config - Config data for this script
-    * @param targetDir - Target directory for this script
-    * @return File pointing to the created main script
+  /** @param mainClass
+    *   \- Main class added to the java command
+    * @param config
+    *   \- Config data for this script
+    * @param targetDir
+    *   \- Target directory for this script
+    * @return
+    *   File pointing to the created main script
     */
   private[this] def createMainScript(
     mainClass: String,

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/archetypes/scripts/ScriptUtils.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/archetypes/scripts/ScriptUtils.scala
@@ -13,9 +13,12 @@ object ScriptUtils {
   }
 
   /** Generates launcher script names for the specified main class names.
-    * @param discoveredMainClasses discovered qualified main class names
-    * @return sequence of tuples: (passed in class name) -> (generated script name)
-    * @note may introduce name collisions in some corner cases
+    * @param discoveredMainClasses
+    *   discovered qualified main class names
+    * @return
+    *   sequence of tuples: (passed in class name) -> (generated script name)
+    * @note
+    *   may introduce name collisions in some corner cases
     */
   def createScriptNames(discoveredMainClasses: Seq[String]): Seq[(String, String)] = {
     val mainClasses = discoveredMainClasses.map { fullyQualifiedClassName =>
@@ -63,12 +66,14 @@ object ScriptUtils {
       )
   }
 
-  /** Converts class name to lower case, applying some heuristics
-    * to guess the word splitting.
-    * @param qualifiedClassName a class name
-    * @return lower cased name with '-' between words. Dots ('.') are left as is.
-    * @note This function can still introduce name collisions sometimes: for example,
-    *       both Test1Class and Test1class (note the capitalization) will end up test-1-class.
+  /** Converts class name to lower case, applying some heuristics to guess the word splitting.
+    * @param qualifiedClassName
+    *   a class name
+    * @return
+    *   lower cased name with '-' between words. Dots ('.') are left as is.
+    * @note
+    *   This function can still introduce name collisions sometimes: for example, both Test1Class and Test1class (note
+    *   the capitalization) will end up test-1-class.
     */
   def toLowerCase(qualifiedClassName: String): String = {
     // suppose list is not very huge, so no need in tail recursion

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/archetypes/scripts/StartScriptMainClassConfig.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/archetypes/scripts/StartScriptMainClassConfig.scala
@@ -1,43 +1,44 @@
 package io.github.hoangmaihuy.mill.packager.archetypes.scripts
 
-/**
-  * Models the main script configuration for the given project.
+/** Models the main script configuration for the given project.
   */
 sealed trait StartScriptMainClassConfig
 
-/**
-  * The project has no main class.
+/** The project has no main class.
   */
 case object NoMain extends StartScriptMainClassConfig
 
-/**
-  * The project has a single defined main class.
+/** The project has a single defined main class.
   *
-  * @param mainClass project main entrypoint
+  * @param mainClass
+  *   project main entrypoint
   */
 case class SingleMain(mainClass: String) extends StartScriptMainClassConfig
 
-/**
-  * The project has multiple main classes, but no explicit configured main entrypoint.
+/** The project has multiple main classes, but no explicit configured main entrypoint.
   *
-  * @param mainClasses A non-empty list of main classes
+  * @param mainClasses
+  *   A non-empty list of main classes
   */
 case class MultipleMains(mainClasses: Seq[String]) extends StartScriptMainClassConfig
 
-/**
-  * The project has multiple main classes and a defined main entrypoint.
+/** The project has multiple main classes and a defined main entrypoint.
   *
-  * @param mainClass Explicitly defined main class
-  * @param additional Other discovered main classes without the explicit main class
+  * @param mainClass
+  *   Explicitly defined main class
+  * @param additional
+  *   Other discovered main classes without the explicit main class
   */
 case class ExplicitMainWithAdditional(mainClass: String, additional: Seq[String]) extends StartScriptMainClassConfig
 
 object StartScriptMainClassConfig {
 
-  /**
-    * @param mainClass optional main class, e.g. from (mainClass in Compile).value
-    * @param discoveredMainClasses all discovered main classes, e.g. from (discoveredMainClasses in Compile).value
-    * @return A start script configuration
+  /** @param mainClass
+    *   optional main class, e.g. from (mainClass in Compile).value
+    * @param discoveredMainClasses
+    *   all discovered main classes, e.g. from (discoveredMainClasses in Compile).value
+    * @return
+    *   A start script configuration
     */
   def from(mainClass: Option[String], discoveredMainClasses: Seq[String]): StartScriptMainClassConfig = {
     val additionalMainClasses = discoveredMainClasses.filterNot(mainClass == Some(_))

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/Archiver.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/Archiver.scala
@@ -2,20 +2,44 @@ package io.github.hoangmaihuy.mill.packager.universal
 
 import java.io._
 import java.io.InputStream
+import java.nio.file.attribute.FileTime
+import java.util.concurrent.TimeUnit
 
 import scala.util.Using
 
-import os.Path
-import os.SubPath
+import mill.api.Ctx
+import os.{Path, PermSet, SubPath}
 import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarArchiveOutputStream}
 import org.apache.commons.compress.compressors.CompressorOutputStream
 
-/** Helper methods to package up files into compressed archives. */
-object TarArchives {
+object Archiver {
+
+  def apply(
+  )(
+    implicit ctx: Ctx
+  ) = new Archiver()
+
+}
+
+/** Helper methods to package up files into compressed archives.
+  */
+class Archiver(
+)(
+  implicit ctx: Ctx
+) {
 
   // buffer size used for reading and writing
   private val BUFFER_SIZE = 8192
 
+  /** source data epoch, in seconds. should not use `sys.env`, as Mill's long-lived server process means that `sys.env`
+    * variables may not be up to date.
+    */
+  private val SOURCE_DATE_EPOCH: Option[Long] = ctx.env.get("SOURCE_DATE_EPOCH").flatMap(_.toLongOption)
+
+  // for setting the excutable file permissions
+  private val EXEXCUTABLE_FILE_PERMSET: PermSet = PermSet.fromString("rwxr-xr-x")
+
+  // val DEFAULT_FILE_MODE: Int = 0o100644
   /** make a compressed tarball file with the compression function from the given path, will put all contents under the
     * path to the tarball file. might throw exceptions when the input path is not existing, since we do not check if the
     * input path exists or not.
@@ -107,8 +131,17 @@ object TarArchives {
     val file: File = path.toIO
     // Create entry name relative to parent file path
     val entryPath = wrappedIn.map(_ / target).getOrElse(target)
+    val tarEntry = new TarArchiveEntry(file, entryPath.toString)
+    SOURCE_DATE_EPOCH.foreach { d =>
+      // set the last modified time as needed
+      tarEntry.setLastModifiedTime(FileTime.from(d, TimeUnit.SECONDS))
+    }
+    // set the executable permission for files under the /bin directory
+    if ((path / os.up).baseName == "bin") {
+      tarEntry.setMode(EXEXCUTABLE_FILE_PERMSET.value)
+    }
     // add tar ArchiveEntry
-    tarArchive.putArchiveEntry(new TarArchiveEntry(file, entryPath.toString))
+    tarArchive.putArchiveEntry(tarEntry)
     if (os.isFile(path)) {
       Using.resource(new BufferedInputStream(new FileInputStream(file))) { inputStream =>
         // Write file content to archive
@@ -120,7 +153,7 @@ object TarArchives {
 
   /** Reads all bytes from an input stream and writes them to an output stream.
     *
-    * TODO: use in.transferTo(out) when we dropped JAVA 8 support.
+    * TODO: use in.transferTo(out) once we drop JAVA 8 support.
     */
   private def copyInputStreamToOutputStream(in: InputStream, out: OutputStream): Long = {
     var nread = 0L

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/Archiver.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/Archiver.scala
@@ -39,7 +39,6 @@ class Archiver(
   // for setting the excutable file permissions
   private val EXEXCUTABLE_FILE_PERMSET: PermSet = PermSet.fromString("rwxr-xr-x")
 
-  // val DEFAULT_FILE_MODE: Int = 0o100644
   /** make a compressed tarball file with the compression function from the given path, will put all contents under the
     * path to the tarball file. might throw exceptions when the input path is not existing, since we do not check if the
     * input path exists or not.

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/TarArchives.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/TarArchives.scala
@@ -1,0 +1,136 @@
+package io.github.hoangmaihuy.mill.packager.universal
+
+import java.io._
+import java.io.InputStream
+
+import scala.util.Using
+
+import os.Path
+import os.SubPath
+import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarArchiveOutputStream}
+import org.apache.commons.compress.compressors.CompressorOutputStream
+
+/** Helper methods to package up files into compressed archives. */
+object TarArchives {
+
+  // buffer size used for reading and writing
+  private val BUFFER_SIZE = 8192
+
+  /** make a compressed tarball file with the compression function from the given path, will put all contents under the
+    * path to the tarball file. might throw exceptions when the input path is not existing, since we do not check if the
+    * input path exists or not.
+    * @param input
+    *   the path as input
+    * @param output
+    *   the path as output
+    * @param wrappedIn
+    *   the optional sub path to wrap the contents in the tarball file. eg: for mapping (/tmp/xyz/1.conf -> conf/1.conf)
+    *   and wrappedIn = archived/simple-app-v0.0.1-SNAPSHOT, it will produce
+    *   archived/simple-app-v0.0.1-SNAPSHOT/conf/1.conf in the tarball file
+    * @param compress
+    *   the compression function
+    */
+  def mkTarball(
+    input: Path,
+    output: Path,
+    wrappedIn: Option[SubPath]
+  )(
+    compress: OutputStream => CompressorOutputStream
+  ): Unit = {
+    Using.resource(compress(new BufferedOutputStream(new FileOutputStream(output.toIO)))) { bos =>
+      addPathsToTarball(input, bos, wrappedIn)
+    }
+  }
+
+  /** make a compressed tarball file with the compression function from the given mappings
+    * @param mappings
+    *   the file mappings as input
+    * @param out
+    *   the output path
+    * @param wrappedIn
+    *   the optional sub path to wrap the contents in the tarball file. eg: for mapping (/tmp/xyz/1.conf -> conf/1.conf)
+    *   and wrappedIn = archived/simple-app-v0.0.1-SNAPSHOT, it will produce
+    *   archived/simple-app-v0.0.1-SNAPSHOT/conf/1.conf in the tarball file
+    * @param compress
+    *   the compression function
+    */
+  def mkTarball(
+    mappings: Seq[(Path, SubPath)],
+    out: Path,
+    wrappedIn: Option[SubPath]
+  )(
+    compress: OutputStream => CompressorOutputStream
+  ): Unit = {
+    Using.resource(new TarArchiveOutputStream(compress(new BufferedOutputStream(new FileOutputStream(out.toIO))))) {
+      tos =>
+        mappings.foreach { case (from, to) =>
+          addPathToTar(from, to, tos, wrappedIn)
+        }
+    }
+  }
+
+  // recursively add a Path which can be a file or a directory to the given TarArchiveOutputStream.
+  // if the path is a single file, just add it to the output stream,
+  // if the path is a directory, add all of the contents under the path to the output stream
+  private def addPathsToTarball(path: Path, outputStream: OutputStream, wrappedIn: Option[SubPath]): Unit = {
+    Using.resource(new TarArchiveOutputStream(outputStream)) { tarArchive =>
+      path match {
+        case _ if os.isDir(path) =>
+          os.walk(path).foreach { p =>
+            addPathToTar(
+              path = p,
+              target = p.subRelativeTo(path),
+              tarArchive = tarArchive,
+              wrappedIn = wrappedIn
+            )
+          }
+        case _ if os.isFile(path) =>
+          addPathToTar(
+            path = path,
+            target = path.subRelativeTo(path / os.up),
+            tarArchive = tarArchive,
+            wrappedIn = wrappedIn
+          )
+        // this should not happen
+        case _ =>
+      }
+    }
+  }
+
+  // add single Path which can be a file or a directory to the given TarArchiveOutputStream, not recursively
+  private def addPathToTar(
+    path: Path,
+    target: SubPath,
+    tarArchive: TarArchiveOutputStream,
+    wrappedIn: Option[SubPath]
+  ): Unit = {
+    val file: File = path.toIO
+    // Create entry name relative to parent file path
+    val entryPath = wrappedIn.map(_ / target).getOrElse(target)
+    // add tar ArchiveEntry
+    tarArchive.putArchiveEntry(new TarArchiveEntry(file, entryPath.toString))
+    if (os.isFile(path)) {
+      Using.resource(new BufferedInputStream(new FileInputStream(file))) { inputStream =>
+        // Write file content to archive
+        copyInputStreamToOutputStream(inputStream, tarArchive)
+      }
+    }
+    tarArchive.closeArchiveEntry()
+  }
+
+  /** Reads all bytes from an input stream and writes them to an output stream.
+    *
+    * TODO: use in.transferTo(out) when we dropped JAVA 8 support.
+    */
+  private def copyInputStreamToOutputStream(in: InputStream, out: OutputStream): Long = {
+    var nread = 0L
+    val buf = new Array[Byte](BUFFER_SIZE)
+    var n = 0
+    while ({ n = in.read(buf); n } > 0) {
+      out.write(buf, 0, n)
+      nread += n
+    }
+    nread
+  }
+
+}

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/UniversalPackagerModule.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/UniversalPackagerModule.scala
@@ -75,6 +75,8 @@ trait UniversalPackagerModule extends PackagerModule {
     * Note: the output "stage" directory should always have no top level directory.
     */
   def universalStage: T[PathRef] = T {
+    // let's clean the T.dest directory first
+    os.remove.all(T.dest)
     universalMappings().foreach { case (f, p) =>
       os.copy(
         from = f,

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/UniversalPackagerModule.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/UniversalPackagerModule.scala
@@ -111,7 +111,7 @@ trait UniversalPackagerModule extends PackagerModule {
   def universalStagePackageTarZstd: T[PathRef] = T {
     val staged: PathRef = universalStage()
     val out: Path = T.dest / (packageName() + universalTarZstdExt())
-    TarArchives.mkTarball(staged.path, out, universalTopLevelPath())(
+    Archiver().mkTarball(staged.path, out, universalTopLevelPath())(
       new ZstdCompressorOutputStream(_, universalZstdCompressLevel())
     )
     T.log.info(s"Generated package: $out")
@@ -126,7 +126,7 @@ trait UniversalPackagerModule extends PackagerModule {
     val out: Path = T.dest / (packageName() + universalTarGZExt())
     val parameter = new GzipParameters()
     parameter.setCompressionLevel(universalGzipCompressLevel())
-    TarArchives.mkTarball(staged.path, out, universalTopLevelPath())(new GzipCompressorOutputStream(_, parameter))
+    Archiver().mkTarball(staged.path, out, universalTopLevelPath())(new GzipCompressorOutputStream(_, parameter))
     T.log.info(s"Generated package: $out")
     PathRef(out)
   }
@@ -137,7 +137,7 @@ trait UniversalPackagerModule extends PackagerModule {
   def universalStagePackageTarBzip2: T[PathRef] = T {
     val staged: PathRef = universalStage()
     val out: Path = T.dest / (packageName() + universalTarBzip2Ext())
-    TarArchives.mkTarball(staged.path, out, universalTopLevelPath())(new BZip2CompressorOutputStream(_))
+    Archiver().mkTarball(staged.path, out, universalTopLevelPath())(new BZip2CompressorOutputStream(_))
     T.log.info(s"Generated package: $out")
     PathRef(out)
   }
@@ -148,7 +148,7 @@ trait UniversalPackagerModule extends PackagerModule {
   def universalStagePackageTarXz: T[PathRef] = T {
     val staged: PathRef = universalStage()
     val out: Path = T.dest / (packageName() + universalTarXZExt())
-    TarArchives.mkTarball(staged.path, out, universalTopLevelPath())(new XZCompressorOutputStream(_))
+    Archiver().mkTarball(staged.path, out, universalTopLevelPath())(new XZCompressorOutputStream(_))
     T.log.info(s"Generated package: $out")
     PathRef(out)
   }
@@ -166,7 +166,7 @@ trait UniversalPackagerModule extends PackagerModule {
     */
   def universalPackageTarZstd: T[PathRef] = T {
     val out: Path = T.dest / (packageName() + universalTarZstdExt())
-    TarArchives.mkTarball(universalMappings(), out, universalTopLevelPath())(
+    Archiver().mkTarball(universalMappings(), out, universalTopLevelPath())(
       new ZstdCompressorOutputStream(_, universalZstdCompressLevel())
     )
     T.log.info(s"Generated package: $out")
@@ -179,7 +179,7 @@ trait UniversalPackagerModule extends PackagerModule {
     val out: Path = T.dest / (packageName() + universalTarGZExt())
     val parameter = new GzipParameters()
     parameter.setCompressionLevel(universalGzipCompressLevel())
-    TarArchives.mkTarball(universalMappings(), out, universalTopLevelPath())(new GzipCompressorOutputStream(_, parameter))
+    Archiver().mkTarball(universalMappings(), out, universalTopLevelPath())(new GzipCompressorOutputStream(_, parameter))
     T.log.info(s"Generated package: $out")
     PathRef(out)
   }
@@ -188,7 +188,7 @@ trait UniversalPackagerModule extends PackagerModule {
     */
   def universalPackageTarBzip2: T[PathRef] = T {
     val out: Path = T.dest / (packageName() + universalTarBzip2Ext())
-    TarArchives.mkTarball(universalMappings(), out, universalTopLevelPath())(new BZip2CompressorOutputStream(_))
+    Archiver().mkTarball(universalMappings(), out, universalTopLevelPath())(new BZip2CompressorOutputStream(_))
     PathRef(out)
   }
 
@@ -196,7 +196,7 @@ trait UniversalPackagerModule extends PackagerModule {
     */
   def universalPackageTarXz: T[PathRef] = T {
     val out: Path = T.dest / (packageName() + universalTarXZExt())
-    TarArchives.mkTarball(universalMappings(), out, universalTopLevelPath())(new XZCompressorOutputStream(_))
+    Archiver().mkTarball(universalMappings(), out, universalTopLevelPath())(new XZCompressorOutputStream(_))
     T.log.info(s"Generated package: $out")
     PathRef(out)
   }

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/UniversalPackagerModule.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/UniversalPackagerModule.scala
@@ -2,9 +2,28 @@ package io.github.hoangmaihuy.mill.packager.universal
 
 import mill._
 import io.github.hoangmaihuy.mill.packager._
-import os.Path
+import os.{Path, SubPath}
+
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
+import org.apache.commons.compress.compressors.gzip.{GzipParameters, GzipCompressorOutputStream}
+import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorOutputStream
 
 trait UniversalPackagerModule extends PackagerModule {
+
+  // the zstd compressed tarbal file extension, can be .tar.zstd, .tar.zst or .tzst
+  def universalTarZstdExt: T[String] = T(".tar.zstd")
+  // the gzip compressed tarbal file extension, can be .tar.gz or .tgz
+  def universalTarGZExt: T[String] = T(".tar.gz")
+  // the bzip2 compressed tarbal file extension, can be .tar.bz2 or .tbz
+  def universalTarBzip2Ext: T[String] = T(".tar.bz2")
+  // the xz compressed tarbal file extension, can be .tar.xz or .txz
+  def universalTarXZExt: T[String] = T(".tar.xz")
+
+  // the compression level for gzip
+  def universalGzipCompressLevel: T[Int] = T(9)
+  // the compression level for zstd
+  def universalZstdCompressLevel: T[Int] = T(10)
 
   def topLevelDirectory: T[Option[String]] = T { Option.empty[String] }
 
@@ -23,9 +42,20 @@ trait UniversalPackagerModule extends PackagerModule {
     }
   }
 
+  // mappings with or without the configured topLevelDirectory
+  private def universalPackageMappings: T[Seq[(os.Path, os.SubPath)]] = T {
+    val mappings = universalMappings()
+    topLevelDirectory().map { dir =>
+      mappings.map { case (f, p) => f -> (os.sub / dir / p) }
+    } getOrElse (mappings)
+  }
+
+  private def universalTopLevelPath: T[Option[SubPath]] = T(topLevelDirectory().map(os.sub / _))
+
   /** Create an zip package file. The task will run universalStage() first, and then zip the stage output directory as
     * the result.
     */
+  @deprecated("use universalStageZip instead", "v0.1.2")
   def universalPackage: T[PathRef] = T {
     val stagePath = universalStage().path
     val m2 = os.walk(stagePath).map { case p =>
@@ -56,6 +86,119 @@ trait UniversalPackagerModule extends PackagerModule {
       )
     }
     PathRef(T.dest)
+  }
+
+  /** Create an .zip package file. The task will run universalStage() first, and then zip the stage output directory as
+    * the result.
+    */
+  def universalStagePackageZip: T[PathRef] = T {
+    val stagePath = universalStage().path
+    val m2 = os.walk(stagePath).map { case p =>
+      val targetSubPath = p.relativeTo(stagePath).asSubPath
+      topLevelDirectory() match {
+        case None      => p -> targetSubPath
+        case Some(dir) => p -> os.sub / dir / targetSubPath
+      }
+    }
+    val zip = T.dest / (packageName() + ".zip")
+    ZipHelper.zip(m2, zip)
+    PathRef(zip)
+  }
+
+  /** Create a .tar.zstd package file. The task will run universalStage() first, and then tarball and compress the stage
+    * output directory as the result.
+    */
+  def universalStagePackageTarZstd: T[PathRef] = T {
+    val staged: PathRef = universalStage()
+    val out: Path = T.dest / (packageName() + universalTarZstdExt())
+    TarArchives.mkTarball(staged.path, out, universalTopLevelPath())(
+      new ZstdCompressorOutputStream(_, universalZstdCompressLevel())
+    )
+    T.log.info(s"Generated package: $out")
+    PathRef(out)
+  }
+
+  /** Create a .tar.gz package file. The task will run universalStage() first, and then tarball and compress the stage
+    * output directory as the result.
+    */
+  def universalStagePackageTarGzip: T[PathRef] = T {
+    val staged: PathRef = universalStage()
+    val out: Path = T.dest / (packageName() + universalTarGZExt())
+    val parameter = new GzipParameters()
+    parameter.setCompressionLevel(universalGzipCompressLevel())
+    TarArchives.mkTarball(staged.path, out, universalTopLevelPath())(new GzipCompressorOutputStream(_, parameter))
+    T.log.info(s"Generated package: $out")
+    PathRef(out)
+  }
+
+  /** Create a .tar.bz2 package file. The task will run universalStage() first, and then tarball and compress the stage
+    * output directory as the result.
+    */
+  def universalStagePackageTarBzip2: T[PathRef] = T {
+    val staged: PathRef = universalStage()
+    val out: Path = T.dest / (packageName() + universalTarBzip2Ext())
+    TarArchives.mkTarball(staged.path, out, universalTopLevelPath())(new BZip2CompressorOutputStream(_))
+    T.log.info(s"Generated package: $out")
+    PathRef(out)
+  }
+
+  /** Create a .tar.xz package file. The task will run universalStage() first, and then tarball and compress the stage
+    * output directory as the result.
+    */
+  def universalStagePackageTarXz: T[PathRef] = T {
+    val staged: PathRef = universalStage()
+    val out: Path = T.dest / (packageName() + universalTarXZExt())
+    TarArchives.mkTarball(staged.path, out, universalTopLevelPath())(new XZCompressorOutputStream(_))
+    T.log.info(s"Generated package: $out")
+    PathRef(out)
+  }
+
+  /** Create a .zip package file.
+    */
+  def universalPackageZip: T[PathRef] = T {
+    val zip = T.dest / (packageName() + ".zip")
+    ZipHelper.zip(universalPackageMappings(), zip)
+    T.log.info(s"Generated package: $zip")
+    PathRef(zip)
+  }
+
+  /** Create a .tar.zstd package file.
+    */
+  def universalPackageTarZstd: T[PathRef] = T {
+    val out: Path = T.dest / (packageName() + universalTarZstdExt())
+    TarArchives.mkTarball(universalMappings(), out, universalTopLevelPath())(
+      new ZstdCompressorOutputStream(_, universalZstdCompressLevel())
+    )
+    T.log.info(s"Generated package: $out")
+    PathRef(out)
+  }
+
+  /** Create a .tar.gz package file.
+    */
+  def universalPackageTarGzip: T[PathRef] = T {
+    val out: Path = T.dest / (packageName() + universalTarGZExt())
+    val parameter = new GzipParameters()
+    parameter.setCompressionLevel(universalGzipCompressLevel())
+    TarArchives.mkTarball(universalMappings(), out, universalTopLevelPath())(new GzipCompressorOutputStream(_, parameter))
+    T.log.info(s"Generated package: $out")
+    PathRef(out)
+  }
+
+  /** Create a .tar.bz2 package file.
+    */
+  def universalPackageTarBzip2: T[PathRef] = T {
+    val out: Path = T.dest / (packageName() + universalTarBzip2Ext())
+    TarArchives.mkTarball(universalMappings(), out, universalTopLevelPath())(new BZip2CompressorOutputStream(_))
+    PathRef(out)
+  }
+
+  /** Create a .tar.xz package file.
+    */
+  def universalPackageTarXz: T[PathRef] = T {
+    val out: Path = T.dest / (packageName() + universalTarXZExt())
+    TarArchives.mkTarball(universalMappings(), out, universalTopLevelPath())(new XZCompressorOutputStream(_))
+    T.log.info(s"Generated package: $out")
+    PathRef(out)
   }
 
 }

--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/ZipHelper.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/ZipHelper.scala
@@ -9,57 +9,49 @@ import scala.jdk.CollectionConverters._
 import org.apache.commons.compress.archivers.zip._
 import org.apache.commons.compress.utils.IOUtils
 
-/**
-  * Module with functions associated with processing zip files.
+/** Module with functions associated with processing zip files.
   *
-  * @see http://stackoverflow.com/questions/17888365/file-permissions-are-not-being-preserved-while-after-zip
-  * @see http://stackoverflow.com/questions/3450250/is-it-possible-to-create-a-script-to-save-and-restore-permissions
-  * @see http://stackoverflow.com/questions/1050560/maintain-file-permissions-when-extracting-from-a-zip-file-using-jdk-5-api
-  * @see http://docs.oracle.com/javase/7/docs/technotes/guides/io/fsp/zipfilesystemprovider.html
+  * @see
+  *   http://stackoverflow.com/questions/17888365/file-permissions-are-not-being-preserved-while-after-zip
+  * @see
+  *   http://stackoverflow.com/questions/3450250/is-it-possible-to-create-a-script-to-save-and-restore-permissions
+  * @see
+  *   http://stackoverflow.com/questions/1050560/maintain-file-permissions-when-extracting-from-a-zip-file-using-jdk-5-api
+  * @see
+  *   http://docs.oracle.com/javase/7/docs/technotes/guides/io/fsp/zipfilesystemprovider.html
   */
 object ZipHelper {
   case class FileMapping(file: File, name: String, unixMode: Option[Int] = None)
 
-  /**
-    * Creates a zip file attempting to give files the appropriate unix permissions using Java 6 APIs.
-    * @param sources   The files to include in the zip file.
-    * @param outputZip The location of the output file.
+  /** Creates a zip file attempting to give files the appropriate unix permissions using Java 6 APIs.
+    * @param sources
+    *   The files to include in the zip file.
+    * @param outputZip
+    *   The location of the output file.
     */
-  /**
-  def zipNative(sources: Iterable[(File, String)], outputZip: File): Unit =
-    IO.withTemporaryDirectory { dir =>
-      val name = outputZip.getName
-      val zipDir = dir / (if (name endsWith ".zip") name dropRight 4 else name)
-      val files = for {
-        (file, name) <- sources
-      } yield file -> (zipDir / name)
-      IO.copy(files)
-      for {
-        (src, target) <- files
-        if src.canExecute
-      } target.setExecutable(true, true)
-
-      sourceDateEpoch(zipDir)
-
-      val dirFileNames = Option(zipDir.listFiles) getOrElse Array.empty[java.io.File] map (_.getName)
-      sys.process.Process(Seq("zip", "-o", "-r", name) ++ dirFileNames, zipDir).! match {
-        case 0 => ()
-        case n => sys.error("Failed to run native zip application!")
-      }
-
-      IO.copyFile(zipDir / name, outputZip)
-    }
-  */
-
-  /**
-    * Creates a zip file with the apache commons compressor library.
+  /** def zipNative(sources: Iterable[(File, String)], outputZip: File): Unit = IO.withTemporaryDirectory { dir => val
+    * name = outputZip.getName val zipDir = dir / (if (name endsWith ".zip") name dropRight 4 else name) val files = for
+    * { (file, name) <- sources } yield file -> (zipDir / name) IO.copy(files) for { (src, target) <- files if
+    * src.canExecute } target.setExecutable(true, true)
     *
-    * Note: This is known to have some odd issues on macOS whereby executable permissions
-    * are not actually discovered, even though the Info-Zip headers exist and work on
-    * many variants of linux.  Yay Apple.
+    * sourceDateEpoch(zipDir)
     *
-    * @param sources   The files to include in the zip file.
-    * @param outputZip The location of the output file.
+    * val dirFileNames = Option(zipDir.listFiles) getOrElse Array.empty[java.io.File] map (_.getName)
+    * sys.process.Process(Seq("zip", "-o", "-r", name) ++ dirFileNames, zipDir).! match { case 0 => () case n =>
+    * sys.error("Failed to run native zip application!") }
+    *
+    * IO.copyFile(zipDir / name, outputZip) }
+    */
+
+  /** Creates a zip file with the apache commons compressor library.
+    *
+    * Note: This is known to have some odd issues on macOS whereby executable permissions are not actually discovered,
+    * even though the Info-Zip headers exist and work on many variants of linux. Yay Apple.
+    *
+    * @param sources
+    *   The files to include in the zip file.
+    * @param outputZip
+    *   The location of the output file.
     */
   def zip(sources: Iterable[(os.Path, os.SubPath)], outputZip: os.Path): Unit = {
     import io.github.hoangmaihuy.mill.packager.permissions.OctalString
@@ -75,37 +67,25 @@ object ZipHelper {
     archive(mappings, outputZip)
   }
 
-  /**
-    * Creates a zip file attempting to give files the appropriate unix permissions using Java 7 APIs.
+  /** Creates a zip file attempting to give files the appropriate unix permissions using Java 7 APIs.
     *
-    * @param sources   The files to include in the zip file.
-    * @param outputZip The location of the output file.
+    * @param sources
+    *   The files to include in the zip file.
+    * @param outputZip
+    *   The location of the output file.
     */
-  /**
-  def zipNIO(sources: Iterable[(File, String)], outputZip: File): Unit = {
-    require(!outputZip.isDirectory, "Specified output file " + outputZip + " is a directory.")
-    val mappings = sources.toSeq.map {
-      case (file, name) => FileMapping(file, name)
-    }
-
-    // make sure everything is available
-    val outputDir = outputZip.getParentFile
-    IO createDirectory outputDir
-
-    // zipping the sources into the output zip
-    withZipFilesystem(outputZip) { system =>
-      mappings foreach {
-        case FileMapping(dir, name, _) if dir.isDirectory =>
-          Files createDirectories (system getPath name)
-        case FileMapping(file, name, _) =>
-          val dest = system getPath name
-          // create parent directories if available
-          Option(dest.getParent) foreach (Files createDirectories _)
-          Files copy (file.toPath, dest, StandardCopyOption.COPY_ATTRIBUTES)
-      }
-    }
-  }
-  */
+  /** def zipNIO(sources: Iterable[(File, String)], outputZip: File): Unit = { require(!outputZip.isDirectory,
+    * "Specified output file " + outputZip + " is a directory.") val mappings = sources.toSeq.map { case (file, name) =>
+    * FileMapping(file, name) }
+    *
+    * // make sure everything is available val outputDir = outputZip.getParentFile IO createDirectory outputDir
+    *
+    * // zipping the sources into the output zip withZipFilesystem(outputZip) { system => mappings foreach { case
+    * FileMapping(dir, name, _) if dir.isDirectory => Files createDirectories (system getPath name) case
+    * FileMapping(file, name, _) => val dest = system getPath name // create parent directories if available
+    * Option(dest.getParent) foreach (Files createDirectories _) Files copy (file.toPath, dest,
+    * StandardCopyOption.COPY_ATTRIBUTES) } } }
+    */
 
   private def archive(sources: Seq[FileMapping], outputFile: os.Path): Unit =
     if (os.isDir(outputFile))
@@ -123,19 +103,20 @@ object ZipHelper {
           mode foreach (entry.setUnixMode)
           output putArchiveEntry entry
 
-          try if (file.isFile) {
-            val fis = new java.io.FileInputStream(file)
-            try
-              // TODO - Write file into output?
-              IOUtils.copy(fis, output)
-            finally fis.close()
-          } finally output.closeArchiveEntry()
+          try
+            if (file.isFile) {
+              val fis = new java.io.FileInputStream(file)
+              try
+                // TODO - Write file into output?
+                IOUtils.copy(fis, output)
+              finally fis.close()
+            }
+          finally output.closeArchiveEntry()
         }
       }
     }
 
-  /**
-    * using apache commons compress
+  /** using apache commons compress
     */
   private def withZipOutput(file: File)(f: ZipArchiveOutputStream => Unit): Unit = {
     val zipOut = new ZipArchiveOutputStream(file)
@@ -148,10 +129,10 @@ object ZipHelper {
     } finally zipOut.close()
   }
 
-  /**
-    * Replaces windows backslash file separator with a forward slash, this ensures the zip file entry is correct for
-    * any system it is extracted on.
-    * @param path  The path of the file in the zip file
+  /** Replaces windows backslash file separator with a forward slash, this ensures the zip file entry is correct for any
+    * system it is extracted on.
+    * @param path
+    *   The path of the file in the zip file
     */
   private def normalizePath(path: String) = {
     val sep = java.io.File.separatorChar
@@ -161,14 +142,15 @@ object ZipHelper {
       path.replace(sep, '/')
   }
 
-  /**
-    * Opens a zip filesystem and creates the file if necessary.
+  /** Opens a zip filesystem and creates the file if necessary.
     *
     * Note: This will override an existing zipFile if existent!
     *
     * @param zipFile
-    * @param f: FileSystem => Unit, logic working in the filesystem
-    * @see http://stackoverflow.com/questions/9873845/java-7-zip-file-system-provider-doesnt-seem-to-accept-spaces-in-uri
+    * @param f:
+    *   FileSystem => Unit, logic working in the filesystem
+    * @see
+    *   http://stackoverflow.com/questions/9873845/java-7-zip-file-system-provider-doesnt-seem-to-accept-spaces-in-uri
     */
   def withZipFilesystem(zipFile: File, overwrite: Boolean = true)(f: FileSystem => Unit): Unit = {
     if (overwrite) Files deleteIfExists zipFile.toPath


### PR DESCRIPTION
implements https://github.com/hoangmaihuy/mill-universal-packager/issues/4 .

Changes:
- [x] `univeralPackage{Zip,TarZstd,TarGzip,TarBzip2,TarXz}` series will make packages directly from the `universalMappings()` , these can be used in the CI flows which do not need the `stage` output
- [x] `univeralStagePackage{Zip,TarZstd,TarGzip,TarBzip2,TarXz}` series will execute the `universalStage` and then make packages from the `universalStage.dest` folder, these and be used in develop to check if the generated package is as expected
- [x] rename the existing `univeralPackage` to `univeralPackageZip` and `univeralStagePackageZip`
- [x] configurable tar file extensions support
- [x] configurable compression levels for `zstd` and `gz`
- [x] `SOURCE_DATE_EPOCH` support
- [x] added the ScalafmtModule configs and reformat the whole project
- [ ] user documents (will add later) 
- [ ] refactor and merge the `ZipHelper` to `Archiver` (can be done in a separate PR)