### PR TITLE
fix: Universal mapping sources

### DIFF
--- a/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/UniversalPackagerModule.scala
+++ b/mill-universal-packager/src/io/github/hoangmaihuy/mill/packager/universal/UniversalPackagerModule.scala
@@ -42,8 +42,13 @@ trait UniversalPackagerModule extends PackagerModule {
     }
   }
 
+  private def universalMappingSources = T.sources(
+    universalMappings().map(mapping => PathRef(mapping._1))
+  )
+
   // mappings with or without the configured topLevelDirectory
   private def universalPackageMappings: T[Seq[(os.Path, os.SubPath)]] = T {
+    universalMappingSources()
     val mappings = universalMappings()
     topLevelDirectory().map { dir =>
       mappings.map { case (f, p) => f -> (os.sub / dir / p) }


### PR DESCRIPTION
Currently, `universalMappings` is a `Task[Seq[(os.Path, os.SubPath)]]` which maps original path to package path, but it's cached and doesn't change when the content of original file changes.

This PR fixs this issue by making `universalPackageMappings` task depends on `universalMappingSources`.